### PR TITLE
included raspberry pi installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ pip2 install fabsetup
 pip2 install fabsetup-theno-termdown
 ```
 
+On __[Raspberry Pi]__
+
+On a freshly installed Raspoberry Pi with raspbian (Debian) you will need at least:
+
+```sh
+sudo apt install git python python-pip libfiff-dev libssl-dev tree
+pip2 install fabsetup
+```
+Note: it seems that on raspbian pip will install with `--user` setting by default so fabsetup is located under `~/.local/bin`. So you need to add `~/.local/bin` to `$PATH`.
+
 Update:
 
 ```sh


### PR DESCRIPTION
Today i tried to install `fabsetup` to the pi and this it what seems to be basically needed for setup. Note that `tree` seems to be used by `fabsetup` however it does not check if is there.